### PR TITLE
Add quiz data integration and fit scoring to explorer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -137,7 +137,7 @@ function App() {
               path="/explore"
               element={
                 <Layout>
-                  <BusinessExplorer />
+                  <BusinessExplorer quizData={quizData} />
                 </Layout>
               }
             />

--- a/src/components/FullReport.tsx
+++ b/src/components/FullReport.tsx
@@ -873,17 +873,53 @@ Business Path Platform - Complete Analysis Report
                 Welcome to Your Full Report!
               </h1>
 
-              <p className="text-xl md:text-2xl text-blue-100 mb-16 leading-relaxed">
+              <p className="text-xl md:text-2xl text-blue-100 mb-12 leading-relaxed">
                 Your personalized business blueprint is ready. Discover your
                 AI-powered analysis, personality insights, and complete roadmap
                 to success.
               </p>
+
+              {/* Scroll Down Arrow */}
+              <motion.button
+                onClick={() => {
+                  const analysisSection = document.querySelector(
+                    '[data-section="ai-analysis"]',
+                  );
+                  if (analysisSection) {
+                    analysisSection.scrollIntoView({
+                      behavior: "smooth",
+                      block: "start",
+                    });
+                  }
+                }}
+                className="group inline-flex flex-col items-center space-y-2 hover:scale-110 transition-all duration-300 cursor-pointer"
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.8, delay: 0.5 }}
+                whileHover={{ y: -5 }}
+                aria-label="Scroll to AI Analysis section"
+              >
+                <span className="text-blue-100 text-sm font-medium group-hover:text-white transition-colors">
+                  View Your Analysis
+                </span>
+                <motion.div
+                  className="w-8 h-8 rounded-full bg-white/20 flex items-center justify-center group-hover:bg-white/30 transition-colors"
+                  animate={{ y: [0, 5, 0] }}
+                  transition={{
+                    duration: 2,
+                    repeat: Infinity,
+                    ease: "easeInOut",
+                  }}
+                >
+                  <ArrowDown className="h-5 w-5 text-white" />
+                </motion.div>
+              </motion.button>
             </motion.div>
           </div>
         </section>
 
         {/* AI Report Section */}
-        <section className="py-20 bg-white">
+        <section className="py-20 bg-white" data-section="ai-analysis">
           <div className="max-w-6xl mx-auto px-8">
             <div className="text-center mb-16">
               <h2 className="text-4xl font-bold text-gray-900 mb-4">

--- a/src/components/Quiz.tsx
+++ b/src/components/Quiz.tsx
@@ -200,15 +200,15 @@ const ExitWarningModal: React.FC<ExitWarningModalProps> = ({
                 ⚠️ You will lose all progress!
               </p>
               <p className="text-red-700">
-                You'll need to restart the entire quiz from the beginning to
-                get your personalized business recommendations.
+                You'll need to restart the entire quiz from the beginning to get
+                your personalized business recommendations.
               </p>
             </div>
 
             <p className="text-gray-600 leading-relaxed">
               The quiz takes 10-15 minutes to complete and provides valuable
-              insights about your perfect business match. Are you sure you
-              want to lose your progress?
+              insights about your perfect business match. Are you sure you want
+              to lose your progress?
             </p>
           </motion.div>
 
@@ -264,7 +264,7 @@ const Quiz: React.FC<QuizProps> = ({ onComplete, onBack }) => {
 
   // Debug logging for exit modal state
   useEffect(() => {
-    console.log('Exit modal state changed:', showExitModal);
+    console.log("Exit modal state changed:", showExitModal);
   }, [showExitModal]);
 
   // Get current round info
@@ -281,38 +281,38 @@ const Quiz: React.FC<QuizProps> = ({ onComplete, onBack }) => {
   // Global keyboard event handler for escape key
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
+      if (event.key === "Escape") {
         event.preventDefault();
         setShowExitModal(true);
       }
     };
 
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
   }, []);
 
   // Add keyboard event handlers for round intro pages
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (showRoundIntro) {
-        if (event.key === 'Enter') {
+        if (event.key === "Enter") {
           event.preventDefault();
           handleRoundContinue();
         }
       }
     };
 
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
   }, [showRoundIntro]);
 
   // Add keyboard event handlers for quiz questions
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       // Only handle Enter key on quiz questions (not round intro pages)
-      if (!showRoundIntro && event.key === 'Enter') {
+      if (!showRoundIntro && event.key === "Enter") {
         event.preventDefault();
-        
+
         // Check if user can proceed (has answered the question)
         const currentStepData = quizSteps[currentStep];
         const canProceed =
@@ -320,15 +320,15 @@ const Quiz: React.FC<QuizProps> = ({ onComplete, onBack }) => {
           (currentStepData?.type !== "multiselect" ||
             (Array.isArray(formData[currentStepData?.field]) &&
               (formData[currentStepData?.field] as any[]).length > 0));
-        
+
         if (canProceed && !isAnimating) {
           handleNext();
         }
       }
     };
 
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
   }, [showRoundIntro, formData, currentStep, isAnimating]);
 
   const handleNext = async () => {
@@ -415,11 +415,11 @@ const Quiz: React.FC<QuizProps> = ({ onComplete, onBack }) => {
   const handleBackButtonClick = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    console.log('Back button clicked - showing exit modal immediately');
-    
+    console.log("Back button clicked - showing exit modal immediately");
+
     // Force immediate state update using callback form
-    setShowExitModal(prevState => {
-      console.log('Setting exit modal to true, previous state was:', prevState);
+    setShowExitModal((prevState) => {
+      console.log("Setting exit modal to true, previous state was:", prevState);
       return true;
     });
   };
@@ -433,18 +433,18 @@ const Quiz: React.FC<QuizProps> = ({ onComplete, onBack }) => {
     if (currentStep > 0) {
       const prevStep = currentStep - 1;
       setCurrentStep(prevStep);
-      
+
       // Find the round for the previous step
       const prevRoundInfo = rounds.find(
         (round) =>
           prevStep >= round.questionRange[0] &&
           prevStep <= round.questionRange[1],
       );
-      
+
       if (prevRoundInfo) {
         setCurrentRound(prevRoundInfo.id);
       }
-      
+
       setShowRoundIntro(false);
     } else {
       // If we're at the first step, show exit modal
@@ -641,6 +641,13 @@ const Quiz: React.FC<QuizProps> = ({ onComplete, onBack }) => {
             )}
           </motion.div>
         </div>
+
+        {/* Exit Warning Modal */}
+        <ExitWarningModal
+          isOpen={showExitModal}
+          onClose={() => setShowExitModal(false)}
+          onConfirmExit={handleExitQuiz}
+        />
       </div>
     );
   }
@@ -870,7 +877,7 @@ const Quiz: React.FC<QuizProps> = ({ onComplete, onBack }) => {
                   {isLastStep ? "Get My Results" : "Next"}
                   {!isLastStep && <ChevronRight className="h-5 w-5 ml-2" />}
                 </button>
-                
+
                 {/* Enter key hint */}
                 {canProceed && (
                   <p className="text-xs text-gray-400 mt-2">
@@ -887,7 +894,9 @@ const Quiz: React.FC<QuizProps> = ({ onComplete, onBack }) => {
       <div className="fixed bottom-4 right-4 z-[9999]">
         <button
           onClick={() => {
-            console.log("Skip button clicked! Generating mock data and navigating...");
+            console.log(
+              "Skip button clicked! Generating mock data and navigating...",
+            );
             const mockData = {
               mainMotivation: "financial-freedom",
               firstIncomeTimeline: "3-6-months",

--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -212,6 +212,7 @@ const Results: React.FC<ResultsProps> = ({ quizData, onBack, userEmail }) => {
 
   const handleViewFullReport = (path: BusinessPath) => {
     if (!canAccessFullReport()) {
+      setSelectedPath(path);
       setPaywallType("full-report");
       setShowUnlockModal(true);
       return;
@@ -227,6 +228,7 @@ const Results: React.FC<ResultsProps> = ({ quizData, onBack, userEmail }) => {
       navigate(`/business/${path.id}`);
     } else {
       // Otherwise, show the paywall modal
+      setSelectedPath(path);
       setPaywallType("learn-more");
       setShowUnlockModal(true);
     }
@@ -247,8 +249,17 @@ const Results: React.FC<ResultsProps> = ({ quizData, onBack, userEmail }) => {
     setShowUnlockModal(false);
     setIsProcessingPayment(false);
 
-    // Navigate to full report analysis page
-    setShowFullReport(true);
+    // Route based on which button was clicked
+    if (paywallType === "learn-more" && selectedPath) {
+      // Navigate to "How business model X works for you" page
+      navigate(`/business/${selectedPath.id}`);
+    } else if (paywallType === "full-report") {
+      // Show the full report
+      setShowFullReport(true);
+    } else {
+      // Default fallback to full report
+      setShowFullReport(true);
+    }
 
     // In a real implementation, this would:
     // 1. Process payment through Stripe

--- a/src/pages/BusinessExplorer.tsx
+++ b/src/pages/BusinessExplorer.tsx
@@ -44,6 +44,30 @@ const BusinessExplorer: React.FC<BusinessExplorerProps> = ({ quizData }) => {
   const difficulties = ["All", "Beginner", "Intermediate", "Advanced"];
   const fitCategories = ["All", "Best", "Strong", "Possible", "Poor"];
 
+  // Function to determine fit category based on score
+  const getFitCategory = (score: number): string => {
+    if (score >= 80) return "Best";
+    if (score >= 60) return "Strong";
+    if (score >= 40) return "Possible";
+    return "Poor";
+  };
+
+  // Function to get fit category colors
+  const getFitCategoryColor = (category: string): string => {
+    switch (category) {
+      case "Best":
+        return "bg-green-100 text-green-800";
+      case "Strong":
+        return "bg-blue-100 text-blue-800";
+      case "Possible":
+        return "bg-yellow-100 text-yellow-800";
+      case "Poor":
+        return "bg-red-100 text-red-800";
+      default:
+        return "bg-gray-100 text-gray-800";
+    }
+  };
+
   // Calculate fit scores for business models if quiz data exists
   const businessModelsWithFitScores = useMemo(() => {
     if (!quizData || !hasUnlockedAnalysis) {
@@ -75,30 +99,6 @@ const BusinessExplorer: React.FC<BusinessExplorerProps> = ({ quizData }) => {
       };
     });
   }, [quizData, hasUnlockedAnalysis]);
-
-  // Function to determine fit category based on score
-  const getFitCategory = (score: number): string => {
-    if (score >= 80) return "Best";
-    if (score >= 60) return "Strong";
-    if (score >= 40) return "Possible";
-    return "Poor";
-  };
-
-  // Function to get fit category colors
-  const getFitCategoryColor = (category: string): string => {
-    switch (category) {
-      case "Best":
-        return "bg-green-100 text-green-800";
-      case "Strong":
-        return "bg-blue-100 text-blue-800";
-      case "Possible":
-        return "bg-yellow-100 text-yellow-800";
-      case "Poor":
-        return "bg-red-100 text-red-800";
-      default:
-        return "bg-gray-100 text-gray-800";
-    }
-  };
 
   const filteredModels = businessModelsWithFitScores.filter((model) => {
     const categoryMatch =

--- a/src/pages/BusinessExplorer.tsx
+++ b/src/pages/BusinessExplorer.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import {
@@ -12,10 +12,17 @@ import {
 import { businessModels, BusinessModel } from "../data/businessModels";
 import { PaywallModal } from "../components/PaywallModals";
 import { usePaywall } from "../contexts/PaywallContext";
+import { QuizData } from "../types";
+import { generatePersonalizedPaths } from "../utils/quizLogic";
 
-const BusinessExplorer = () => {
+interface BusinessExplorerProps {
+  quizData?: QuizData | null;
+}
+
+const BusinessExplorer: React.FC<BusinessExplorerProps> = ({ quizData }) => {
   const [selectedCategory, setSelectedCategory] = useState<string>("All");
   const [selectedDifficulty, setSelectedDifficulty] = useState<string>("All");
+  const [selectedFitCategory, setSelectedFitCategory] = useState<string>("All");
   const [expandedCard, setExpandedCard] = useState<string | null>(null);
   const [showPaywallModal, setShowPaywallModal] = useState(false);
   const [paywallType, setPaywallType] = useState<
@@ -23,20 +30,85 @@ const BusinessExplorer = () => {
   >("quiz-required");
   const [selectedBusinessId, setSelectedBusinessId] = useState<string>("");
   const navigate = useNavigate();
-  const { hasCompletedQuiz, canAccessBusinessModel, setHasUnlockedAnalysis } = usePaywall();
+  const {
+    hasCompletedQuiz,
+    canAccessBusinessModel,
+    setHasUnlockedAnalysis,
+    hasUnlockedAnalysis,
+  } = usePaywall();
 
   const categories = [
     "All",
     ...Array.from(new Set(businessModels.map((model) => model.category))),
   ];
   const difficulties = ["All", "Beginner", "Intermediate", "Advanced"];
+  const fitCategories = ["All", "Best", "Strong", "Possible", "Poor"];
 
-  const filteredModels = businessModels.filter((model) => {
+  // Calculate fit scores for business models if quiz data exists
+  const businessModelsWithFitScores = useMemo(() => {
+    if (!quizData || !hasUnlockedAnalysis) {
+      return businessModels.map((model) => ({
+        ...model,
+        fitScore: 0,
+        fitCategory: null,
+      }));
+    }
+
+    // Generate personalized paths to get fit scores
+    const personalizedPaths = generatePersonalizedPaths(quizData);
+
+    return businessModels.map((model) => {
+      // Find matching business path by name or similar logic
+      const matchingPath = personalizedPaths.find(
+        (path) =>
+          path.name.toLowerCase().includes(model.title.toLowerCase()) ||
+          model.title.toLowerCase().includes(path.name.toLowerCase()),
+      );
+
+      const fitScore = matchingPath?.fitScore || 0;
+      const fitCategory = getFitCategory(fitScore);
+
+      return {
+        ...model,
+        fitScore,
+        fitCategory,
+      };
+    });
+  }, [quizData, hasUnlockedAnalysis]);
+
+  // Function to determine fit category based on score
+  const getFitCategory = (score: number): string => {
+    if (score >= 80) return "Best";
+    if (score >= 60) return "Strong";
+    if (score >= 40) return "Possible";
+    return "Poor";
+  };
+
+  // Function to get fit category colors
+  const getFitCategoryColor = (category: string): string => {
+    switch (category) {
+      case "Best":
+        return "bg-green-100 text-green-800";
+      case "Strong":
+        return "bg-blue-100 text-blue-800";
+      case "Possible":
+        return "bg-yellow-100 text-yellow-800";
+      case "Poor":
+        return "bg-red-100 text-red-800";
+      default:
+        return "bg-gray-100 text-gray-800";
+    }
+  };
+
+  const filteredModels = businessModelsWithFitScores.filter((model) => {
     const categoryMatch =
       selectedCategory === "All" || model.category === selectedCategory;
     const difficultyMatch =
       selectedDifficulty === "All" || model.difficulty === selectedDifficulty;
-    return categoryMatch && difficultyMatch;
+    const fitCategoryMatch =
+      selectedFitCategory === "All" ||
+      model.fitCategory === selectedFitCategory;
+    return categoryMatch && difficultyMatch && fitCategoryMatch;
   });
 
   const handleCardExpand = (modelId: string) => {
@@ -131,9 +203,28 @@ const BusinessExplorer = () => {
                 ))}
               </select>
             </div>
+            {/* Fit Category Filter - Only show if user has paid */}
+            {hasUnlockedAnalysis && quizData && (
+              <div className="flex items-center gap-2">
+                <label className="text-sm font-medium text-gray-700">
+                  Fit Level:
+                </label>
+                <select
+                  value={selectedFitCategory}
+                  onChange={(e) => setSelectedFitCategory(e.target.value)}
+                  className="px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+                >
+                  {fitCategories.map((fitCategory) => (
+                    <option key={fitCategory} value={fitCategory}>
+                      {fitCategory}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
             <div className="ml-auto text-sm text-gray-600">
-              Showing {filteredModels.length} of {businessModels.length}{" "}
-              business models
+              Showing {filteredModels.length} of{" "}
+              {businessModelsWithFitScores.length} business models
             </div>
           </div>
         </div>
@@ -147,6 +238,10 @@ const BusinessExplorer = () => {
               onLearnMore={handleLearnMore}
               isExpanded={expandedCard === model.id}
               onToggleExpand={() => handleCardExpand(model.id)}
+              showFitBadge={hasUnlockedAnalysis && quizData}
+              fitCategory={model.fitCategory}
+              fitScore={model.fitScore}
+              getFitCategoryColor={getFitCategoryColor}
             />
           ))}
         </div>
@@ -166,7 +261,11 @@ const BusinessExplorer = () => {
         onClose={handlePaywallClose}
         onUnlock={handlePaywallUnlock}
         type={paywallType}
-        title={selectedBusinessId ? businessModels.find(m => m.id === selectedBusinessId)?.title : undefined}
+        title={
+          selectedBusinessId
+            ? businessModels.find((m) => m.id === selectedBusinessId)?.title
+            : undefined
+        }
       />
     </div>
   );
@@ -177,11 +276,19 @@ const BusinessModelCard = ({
   onLearnMore,
   isExpanded,
   onToggleExpand,
+  showFitBadge,
+  fitCategory,
+  fitScore,
+  getFitCategoryColor,
 }: {
-  model: BusinessModel;
+  model: BusinessModel & { fitScore?: number; fitCategory?: string };
   onLearnMore: (businessId: string) => void;
   isExpanded: boolean;
   onToggleExpand: () => void;
+  showFitBadge?: boolean;
+  fitCategory?: string | null;
+  fitScore?: number;
+  getFitCategoryColor?: (category: string) => string;
 }) => {
   const [showAllSkills, setShowAllSkills] = useState(false);
 
@@ -256,11 +363,21 @@ const BusinessModelCard = ({
           <h3 className="text-xl font-bold text-gray-900 flex-1 mr-2 line-clamp-2">
             {model.title}
           </h3>
-          <span
-            className={`px-2 py-1 rounded-full text-xs font-medium flex-shrink-0 ${getDifficultyColor(model.difficulty)}`}
-          >
-            {model.difficulty}
-          </span>
+          <div className="flex flex-col gap-1 items-end">
+            <span
+              className={`px-2 py-1 rounded-full text-xs font-medium flex-shrink-0 ${getDifficultyColor(model.difficulty)}`}
+            >
+              {model.difficulty}
+            </span>
+            {/* Fit Badge - Only show if user has paid */}
+            {showFitBadge && fitCategory && getFitCategoryColor && (
+              <span
+                className={`px-2 py-1 rounded-full text-xs font-medium flex-shrink-0 ${getFitCategoryColor(fitCategory)}`}
+              >
+                {fitCategory} Fit
+              </span>
+            )}
+          </div>
         </div>
 
         <p className="text-gray-600 mb-4 line-clamp-3">{model.description}</p>


### PR DESCRIPTION
This pull request adds quiz data integration and personalized fit scoring to the business explorer page.

Changes made:
- Pass quizData prop to BusinessExplorer component from App.tsx
- Add fit scoring system with categories (Best, Strong, Possible, Poor) based on quiz results
- Add fit category filter dropdown for users who have unlocked analysis
- Display fit badges on business model cards showing personalized match levels
- Add scroll-to-section functionality in FullReport with animated arrow button
- Update Results component to properly handle paywall routing for different actions
- Fix code formatting and quote consistency in Quiz component
- Add newline at end of App.tsx file

The explorer now shows personalized business fit scores when users have completed the quiz and unlocked analysis, helping them identify the most suitable business models based on their quiz responses.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c67bff0097d044048b2b7da08704c501/curry-den)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c67bff0097d044048b2b7da08704c501</projectId>-->
<!--<branchName>curry-den</branchName>-->